### PR TITLE
Study screen controller implementation

### DIFF
--- a/src/main/java/org/flashnotes/flashnotes/Model/FirestoreContext.java
+++ b/src/main/java/org/flashnotes/flashnotes/Model/FirestoreContext.java
@@ -15,7 +15,7 @@ public class FirestoreContext {
         try {
             FirebaseOptions options = new FirebaseOptions.Builder()
 //                    .setCredentials(GoogleCredentials.fromStream(getClass().getResourceAsStream("Key.json")))
-                    .setCredentials(GoogleCredentials.fromStream(new FileInputStream("src/main/resources/Key.json")))
+                    .setCredentials(GoogleCredentials.fromStream(new FileInputStream("Key.json")))
                     .setStorageBucket("flash-notes-74382.appspot.com")
                     .build();
             FirebaseApp.initializeApp(options);

--- a/src/main/java/org/flashnotes/flashnotes/Model/FirestoreContext.java
+++ b/src/main/java/org/flashnotes/flashnotes/Model/FirestoreContext.java
@@ -15,7 +15,7 @@ public class FirestoreContext {
         try {
             FirebaseOptions options = new FirebaseOptions.Builder()
 //                    .setCredentials(GoogleCredentials.fromStream(getClass().getResourceAsStream("Key.json")))
-                    .setCredentials(GoogleCredentials.fromStream(new FileInputStream("Key.json")))
+                    .setCredentials(GoogleCredentials.fromStream(new FileInputStream("src/main/resources/Key.json")))
                     .setStorageBucket("flash-notes-74382.appspot.com")
                     .build();
             FirebaseApp.initializeApp(options);

--- a/src/main/java/org/flashnotes/flashnotes/View/MainRunner.java
+++ b/src/main/java/org/flashnotes/flashnotes/View/MainRunner.java
@@ -10,14 +10,14 @@ import org.flashnotes.flashnotes.Model.FireBaseActions;
 import java.io.File;
 import java.io.IOException;
 
+
 public class MainRunner extends Application {
     @Override
     public void start(Stage stage) throws IOException, FirebaseAuthException {
         FireBaseActions.init();
-        FXMLLoader fxmlLoader = new FXMLLoader(MainRunner.class.getResource("/org/flashnotes/flashnotes/StudyScreen.fxml"));
-        Scene scene = new Scene(fxmlLoader.load(), 800, 600);
-        stage.setTitle("FlashNotes");
-        stage.setResizable(false);
+        FXMLLoader fxmlLoader = new FXMLLoader(MainRunner.class.getResource("/org/flashnotes/flashnotes/SplashScreen.fxml"));
+        Scene scene = new Scene(fxmlLoader.load(), 320, 240);
+        stage.setTitle("Hello!");
         stage.setScene(scene);
         stage.show();
     }

--- a/src/main/java/org/flashnotes/flashnotes/View/MainRunner.java
+++ b/src/main/java/org/flashnotes/flashnotes/View/MainRunner.java
@@ -14,9 +14,10 @@ public class MainRunner extends Application {
     @Override
     public void start(Stage stage) throws IOException, FirebaseAuthException {
         FireBaseActions.init();
-        FXMLLoader fxmlLoader = new FXMLLoader(MainRunner.class.getResource("/org/flashnotes/flashnotes/SplashScreen.fxml"));
-        Scene scene = new Scene(fxmlLoader.load(), 320, 240);
-        stage.setTitle("Hello!");
+        FXMLLoader fxmlLoader = new FXMLLoader(MainRunner.class.getResource("/org/flashnotes/flashnotes/StudyScreen.fxml"));
+        Scene scene = new Scene(fxmlLoader.load(), 800, 600);
+        stage.setTitle("FlashNotes");
+        stage.setResizable(false);
         stage.setScene(scene);
         stage.show();
     }

--- a/src/main/java/org/flashnotes/flashnotes/View/StudyScreenController.java
+++ b/src/main/java/org/flashnotes/flashnotes/View/StudyScreenController.java
@@ -8,6 +8,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import org.flashnotes.flashnotes.Model.Card;
 import org.flashnotes.flashnotes.Model.Deck;
+import org.flashnotes.flashnotes.Model.FireBaseActions;
 import org.flashnotes.flashnotes.Model.User;
 
 import java.net.URL;
@@ -60,12 +61,14 @@ public class StudyScreenController {
 
     Deck currentDeck;
 
+    FireBaseActions fireBaseActions;
+
 
 
     @FXML
     public void initialize() {
-        InMemoryDatabase database = new InMemoryDatabase();
-        currentUser = database.getUser("1");
+        fireBaseActions = FireBaseActions.init();
+        currentUser = fireBaseActions.getCurrentUser();
         currentCardIndex = 1;
         System.out.println("here");
         System.out.println(currentUser);
@@ -127,6 +130,11 @@ public class StudyScreenController {
             isFront = true;
             card.setText("Front:\n" + currentCard.getFront());
         }
+    }
+
+    @FXML
+    public void goToMainMenu(){
+        //implement routing logic when we get that going
     }
 
 

--- a/src/main/java/org/flashnotes/flashnotes/View/StudyScreenController.java
+++ b/src/main/java/org/flashnotes/flashnotes/View/StudyScreenController.java
@@ -90,6 +90,14 @@ public class StudyScreenController {
             isFront = true;
             card.setText("Front:\n" + currentCard.getFront());
             index.setText(currentCardIndex +"/" + currentDeck.getCards().size() + " cards");
+        }else{
+            currentCardIndex = currentDeck.getCards().size();
+            currentCard = currentDeck.getCards().get(currentCardIndex-1);
+            isFront = true;
+            card.setText("Front:\n" + currentCard.getFront());
+            index.setText(currentCardIndex +"/" + currentDeck.getCards().size() + " cards");
+
+
         }
     }
 
@@ -100,6 +108,13 @@ public class StudyScreenController {
             isFront = true;
             card.setText("Front:\n" + currentCard.getFront());
             index.setText(currentCardIndex +"/" + currentDeck.getCards().size() + " cards");
+        }else{
+            currentCardIndex = 1;
+            currentCard = currentDeck.getCards().get(0);
+            isFront = true;
+            card.setText("Front:\n" + currentCard.getFront());
+            index.setText(currentCardIndex +"/" + currentDeck.getCards().size() + " cards");
+
         }
     }
 

--- a/src/main/java/org/flashnotes/flashnotes/View/StudyScreenController.java
+++ b/src/main/java/org/flashnotes/flashnotes/View/StudyScreenController.java
@@ -1,0 +1,118 @@
+package org.flashnotes.flashnotes.View;
+
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.VBox;
+import org.flashnotes.flashnotes.Model.Card;
+import org.flashnotes.flashnotes.Model.Deck;
+import org.flashnotes.flashnotes.Model.User;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+
+public class StudyScreenController {
+
+    @FXML
+    private Label FlashNotes;
+
+    @FXML
+    private Button MatchingGameButton;
+
+    @FXML
+    private AnchorPane anchorPane;
+
+    @FXML
+    private Button backButton;
+
+
+    @FXML
+    private Label home;
+
+    @FXML
+    private Button leftButton;
+
+    @FXML
+    private Button menuIcon;
+
+    @FXML
+    private VBox vBox;
+
+    User currentUser;
+
+    boolean isFront;
+
+    @FXML
+    Card currentCard;
+
+    @FXML
+    Label card;
+
+    @FXML
+            Label index;
+
+    @FXML
+            Label title;
+
+    int currentCardIndex;
+
+    Deck currentDeck;
+
+
+
+    @FXML
+    public void initialize() {
+        InMemoryDatabase database = new InMemoryDatabase();
+        currentUser = database.getUser("1");
+        currentCardIndex = 1;
+        System.out.println("here");
+        System.out.println(currentUser);
+        isFront = true;
+        currentDeck = currentUser.getDecks().get(0);
+        currentDeck.getCards().add(new Card("Objects","I dont know ask the professor"));
+        currentDeck.getCards().add(new Card("random","not random"));
+        currentDeck.getCards().add(new Card("dang","dong"));
+        currentCard = currentUser.getDecks().get(0).getCards().get(0);
+        index.setText(currentCardIndex +"/" + currentDeck.getCards().size() + " cards");
+        card.setText("Front:\n" + currentCard.getFront());
+        title.setText(currentDeck.getNameOfDeck());
+
+
+    }
+
+    @FXML
+    public void previousCard(){
+        if(!(currentCardIndex == 1)){
+            currentCardIndex--;
+            currentCard = currentDeck.getCards().get(currentCardIndex-1);
+            isFront = true;
+            card.setText("Front:\n" + currentCard.getFront());
+            index.setText(currentCardIndex +"/" + currentDeck.getCards().size() + " cards");
+        }
+    }
+
+    @FXML public void nextCard(){
+        if(!(currentCardIndex == currentDeck.getCards().size())){
+            currentCardIndex++;
+            currentCard = currentDeck.getCards().get(currentCardIndex-1);
+            isFront = true;
+            card.setText("Front:\n" + currentCard.getFront());
+            index.setText(currentCardIndex +"/" + currentDeck.getCards().size() + " cards");
+        }
+    }
+
+    @FXML
+    public void switchSide(){
+        if(isFront){
+            isFront = false;
+            card.setText("Back:\n" + currentCard.getBack());
+        }else{
+            isFront = true;
+            card.setText("Front:\n" + currentCard.getFront());
+        }
+    }
+
+
+}

--- a/src/main/resources/org/flashnotes/flashnotes/StudyScreen.fxml
+++ b/src/main/resources/org/flashnotes/flashnotes/StudyScreen.fxml
@@ -13,7 +13,7 @@
 
         <!-- Flash Notes Title -->
         <HBox alignment="CENTER_LEFT" prefHeight="58.0" prefWidth="630.0" spacing="20" style="-fx-padding: 10;">
-            <Label fx:id="FlashNotes" prefHeight="20.0" prefWidth="155.0" style="-fx-font-size: 14; -fx-text-fill: #333333; -fx-font-weight: bold;" stylesheets="@../../../Template.css" text="Flash Notes" />
+            <Label fx:id="FlashNotes" onMousePressed="#goToMainMenu" prefHeight="20.0" prefWidth="155.0" style="-fx-font-size: 14; -fx-text-fill: #333333; -fx-font-weight: bold;" stylesheets="@../../../Template.css" text="Flash Notes" />
             <HBox alignment="CENTER_RIGHT" prefHeight="34.0" prefWidth="439.0" spacing="20" style="-fx-padding: 0;">
                 <Label fx:id="home" style="-fx-font-size: 14; -fx-text-fill: gray;" text="home" />
                 <Button fx:id="menuIcon" style="-fx-font-size: 16px; -fx-background-color: transparent;" text="≡" />

--- a/src/main/resources/org/flashnotes/flashnotes/StudyScreen.fxml
+++ b/src/main/resources/org/flashnotes/flashnotes/StudyScreen.fxml
@@ -6,10 +6,10 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane fx:id="anchorPane" prefHeight="581.0" prefWidth="803.0" style="-fx-background-color: #DBE8F4;" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane fx:id="anchorPane" minHeight="600.0" minWidth="800.0" style="-fx-background-color: #DBE8F4;" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.flashnotes.flashnotes.View.StudyScreenController">
 
     <!-- Centered Content Container -->
-    <VBox fx:id="vBox" alignment="CENTER" layoutX="66.0" layoutY="70.0" prefHeight="430.0" prefWidth="670.0" spacing="20" style="-fx-background-color: #ffffff; -fx-padding: 20; -fx-border-radius: 8; -fx-background-radius: 8; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 8, 0, 0, 4);">
+    <VBox fx:id="vBox" alignment="CENTER" layoutX="51.0" layoutY="85.0" prefHeight="430.0" prefWidth="670.0" spacing="20" style="-fx-background-color: #ffffff; -fx-padding: 20; -fx-border-radius: 8; -fx-background-radius: 8; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 8, 0, 0, 4);">
 
         <!-- Flash Notes Title -->
         <HBox alignment="CENTER_LEFT" prefHeight="58.0" prefWidth="630.0" spacing="20" style="-fx-padding: 10;">
@@ -19,17 +19,17 @@
                 <Button fx:id="menuIcon" style="-fx-font-size: 16px; -fx-background-color: transparent;" text="≡" />
             </HBox>
         </HBox>
-
-        <!-- Question Card as Button -->
-        <Button style="-fx-background-color: #2196F3; -fx-text-fill: white; -fx-font-size: 18px; -fx-padding: 80 100 80 100; -fx-border-radius: 20; -fx-background-radius: 20; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 8, 0, 0, 4);" text="Place Holder Text" />
+      <Label fx:id="title" alignment="CENTER" contentDisplay="CENTER" prefHeight="18.0" prefWidth="148.0" />
+      <Label fx:id="card" alignment="CENTER" contentDisplay="CENTER" maxHeight="300.0" maxWidth="400.0" minHeight="160.0" onMousePressed="#switchSide" prefHeight="150.0" prefWidth="400.0" style="-fx-background-color: #2196F3; -fx-background-radius: 10; -fx-padding: 10;" text="Place Holder" textAlignment="CENTER" wrapText="true" />
+      <Label fx:id="index" text="1/10 cards" />
 
         <!-- Navigation Buttons -->
         <HBox alignment="CENTER" spacing="10">
-            <Button style="-fx-font-size: 16px; -fx-background-radius: 15px; -fx-background-color: #f0f0f0;" text="←" />
-            <Button style="-fx-font-size: 16px; -fx-background-radius: 15px; -fx-background-color: #f0f0f0;" text="→" />
+            <Button fx:id="backButton" onAction="#previousCard" style="-fx-font-size: 16px; -fx-background-radius: 15px; -fx-background-color: #f0f0f0;" text="←" />
+            <Button fx:id="NextButton" onAction="#nextCard" style="-fx-font-size: 16px; -fx-background-radius: 15px; -fx-background-color: #f0f0f0;" text="→" />
         </HBox>
 
         <!-- Matching Game Button -->
-        <Button style="-fx-background-color: #800080; -fx-text-fill: white; -fx-font-size: 16px; -fx-padding: 10 20 10 20;" text="Matching Game" />
+        <Button fx:id="MatchingGameButton" style="-fx-background-color: #800080; -fx-text-fill: white; -fx-font-size: 16px; -fx-padding: 10 20 10 20;" text="Matching Game" />
     </VBox>
 </AnchorPane>


### PR DESCRIPTION
Howdy cowboy, this is going to be a wild ride, mostly because of the amount of Conflicts the fxml file is going to cause and the quick explanation I need to get done. This pull request implements a working StudyScreenController that allows the user to traverse forward and backwards through a deck. Pretty simple stuff. However, I do want to talk about how to access decks app-wide. When a user registers and logs in, their User object is stored in a variable called currentUser. This variable can be accessed through a getter method and allows access to all their information. If you need reference, look at the initialize method in this pull request. It's a decent example of how to perform cross-app user access.